### PR TITLE
optionally use lua scripting for cache cleaning (_removeByMatchingAnyTags method)...

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Works with any Zend Framework project including all versions of Magento!
             <compress_tags>1</compress_tags>  <!-- 0-9 for compression level, recommended: 0 or 1 -->
             <compress_threshold>20480</compress_threshold>  <!-- Strings below this size will not be compressed -->
             <compression_lib>gzip</compression_lib> <!-- Supports gzip, lzf and snappy -->
+            <use_lua>0</use_lua> <!-- Set to 1 if Lua scripts should be used for some operations -->
           </backend_options>
         </cache>
 


### PR DESCRIPTION
method), configurable by the new "use_lua" backend setting (turned off by default).

CAUTION: requires commit 76d1754e0f9df20d4de5feb70ec25 to CRedis submodule in order to work properly.
