### PR TITLE
Always return after lua cleaning script execution, otherwise we will do the job twice (lua and non-lua)

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -366,6 +366,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
                     "return true";
                 $this->_redis->eval($script, $pTags, $sArgs);
             }
+            return;
         }
 
         $ids = $this->getIdsMatchingAnyTags($tags);


### PR DESCRIPTION
Was there on my initial PR, must have gone down the drain sometime along the changes :-)
