### PR TITLE
Support lz4 compression library (through php-ext-lz4, https://github.com/kjdev/php-ext-lz4)

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -155,6 +155,9 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         else if ( function_exists('snappy_compress') ) {
             $this->_compressionLib = 'snappy';
         }
+        else if ( function_exists('lz4_compress')) {
+            $this->_compressionLib = 'l4z';
+        }
         else if ( function_exists('lzf_compress') ) {
             $this->_compressionLib = 'lzf';
         }
@@ -710,6 +713,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
             switch($this->_compressionLib) {
               case 'snappy': $data = snappy_compress($data); break;
               case 'lzf':    $data = lzf_compress($data); break;
+              case 'l4z':    $data = lz4_compress($data,($level > 1 ? true : false)); break;
               case 'gzip':   $data = gzcompress($data, $level); break;
             }
             if( ! $data) {
@@ -730,6 +734,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
             switch(substr($data,0,2)) {
                 case 'sn': return snappy_uncompress(substr($data,5));
                 case 'lz': return lzf_decompress(substr($data,5));
+                case 'l4': return lz4_uncompress(substr($data,5));
                 case 'gz': case 'zc': return gzuncompress(substr($data,5));
             }
         }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Works with any Zend Framework project including all versions of Magento!
             <compress_data>1</compress_data>  <!-- 0-9 for compression level, recommended: 0 or 1 -->
             <compress_tags>1</compress_tags>  <!-- 0-9 for compression level, recommended: 0 or 1 -->
             <compress_threshold>20480</compress_threshold>  <!-- Strings below this size will not be compressed -->
-            <compression_lib>gzip</compression_lib> <!-- Supports gzip, lzf and snappy -->
+            <compression_lib>gzip</compression_lib> <!-- Supports gzip, lzf, lz4 (as l4z) and snappy -->
             <use_lua>0</use_lua> <!-- Set to 1 if Lua scripts should be used for some operations -->
           </backend_options>
         </cache>


### PR DESCRIPTION
lz4 is tested to be faster than las and snappy, used this mod in production for several days before getting a new server with 64GB of RAM :-)
The only catch in this PR is that the setting must be l4z instead of lz4, since I didn't want to mess with the code too much (since you just use the first 2 digits for algo distinction, we wouldn't be able to distinct between lzf and lz4 otherwise)
