### PR TITLE
Multiserver

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -192,7 +192,6 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         $masterName = isset($options['master_name']) ? $options['master_name'] : 'master';
         $selectRandomSlave = isset($options['select_random_slave']) && ($options['select_random_slave'] || $options['select_random_slave'] == 'true');
         $readOnMaster = !isset($options['read_on_master']) || ($options['read_on_master'] || $options['read_on_master'] == 'true');
-        $sentinel = new Credis_Client($backendConfig['host'],$backendConfig['port']);
         $debug = isset($options['debug']) && ($options['debug'] || $options['debug'] == 'true');
         $sentinel = new Credis_Sentinel(new Credis_Client($backendConfig['host'],$backendConfig['port']));
         $this->_redis = $sentinel->getCluster($masterName,$selectRandomSlave,$readOnMaster,$debug);


### PR DESCRIPTION
Hi Colin,

I noticed that Cm_Cache_Backend_Redis can only connect to a single Redis server. For larger setups, it would be nice if we could leverage the Credis_Cluster features.

This pull requests offers Credis_Cluster support with backwards compatibility for the current configuration syntax.

Could you please review the pull request and give me feedback? Could you also explain how I can actually test this on a recent Magento installation where Cm_Cache_Backend_Redis is already there by default?

Cheers
Thijs
