### PR TITLE
removed submodule for Credis and added as Composer Dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/Credis"]
-	path = lib/Credis
-	url = https://github.com/colinmollenhour/credis.git

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require":{
-        "magento-hackathon/magento-composer-installer":"*"
+        "magento-hackathon/magento-composer-installer":"*",
+        "colinmollenhour/credis": "*"
     }
 }

--- a/modman
+++ b/modman
@@ -1,2 +1,1 @@
 Cm/Cache/Backend/*                 app/code/community/Cm/Cache/Backend/
-lib/*                              lib/


### PR DESCRIPTION
resolve #68

you really should not keep ignoring composer. Its used in most big companies to handle many big Projects. I made this change here, and added a modman file in the Credis library.

So now you can still track the new version of the Credis lib, it can be installed via composer and still you can add both with modman and it will still work for you
