### PR TITLE
Failover detection

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -191,7 +191,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
     
     /**
      * @param $options
-     * @return bool
+     * @return array
      * Author: Adam Hall (adamhall@mytuxedo.co.uk)
      * Checks to see if Redis is online, and if not; use the fail over ip, requires pecl redis.
      */


### PR DESCRIPTION
Hi there,

I recently had a requirement to extend the redis cache module to support automatic failover to another server, I've implemented this via the phpredis module, and thusly have a check wrapped around the code to make sure this exists in the php build. Main reason for this direction is I didn't have the time to learn how it works, and any overheads that would be tied to instantiating the credis_client class twice for the check. This code does add an additional overhead, so it should really only be turned on if it is needed.

Thanks!
