### PR TITLE
Slave select

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -92,6 +92,15 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
     /** @var bool */
     protected $_useLua = false;
 
+    /** @var integer */
+    protected $_autoExpireLifetime = 0;
+
+    /** @var string */
+    protected $_autoExpirePattern = '/REQEST/';
+
+    /** @var boolean */
+    protected $_autoExpireRefreshOnLoad = false;
+
     /**
      * Lua's unpack() has a limit on the size of the table imposed by
      * the number of Lua stack slots that a C function can use.
@@ -115,8 +124,9 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
     protected $_slave;
 
     /**
-     * Contruct Zend_Cache Redis backend
+     * Construct Zend_Cache Redis backend
      * @param array $options
+     * @return \Cm_Cache_Backend_Redis
      */
     public function __construct($options = array())
     {
@@ -271,6 +281,18 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         if (isset($options['lua_max_c_stack'])) {
             $this->_luaMaxCStack = (int) $options['lua_max_c_stack'];
         }
+
+        if (isset($options['auto_expire_lifetime'])) {
+            $this->_autoExpireLifetime = (int) $options['auto_expire_lifetime'];
+        }
+
+        if (isset($options['auto_expire_pattern'])) {
+            $this->_autoExpirePattern = (string) $options['auto_expire_pattern'];
+        }
+
+        if (isset($options['auto_expire_refresh_on_load'])) {
+            $this->_autoExpireRefreshOnLoad = (bool) $options['auto_expire_refresh_on_load'];
+        }
     }
 
     /**
@@ -317,7 +339,21 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         if ($data === NULL) {
             return FALSE;
         }
-        return $this->_decodeData($data);
+
+        $decoded = $this->_decodeData($data);
+
+        if ($this->_autoExpireLifetime === 0 || !$this->_autoExpireRefreshOnLoad) {
+            return $decoded;
+        }
+
+        $matches = $this->_matchesAutoExpiringPattern($id);
+        if (!$matches) {
+            return $decoded;
+        }
+
+        $this->_redis->expire(self::PREFIX_KEY.$id, min($this->_autoExpireLifetime, self::MAX_LIFETIME));
+
+        return $decoded;
     }
 
     /**
@@ -353,7 +389,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         else
             $tags = array_flip(array_flip($tags));
 
-        $lifetime = $this->getLifetime($specificLifetime);
+        $lifetime = $this->_getAutoExpiringLifetime($this->getLifetime($specificLifetime), $id);
 
         if ($this->_useLua) {
             $sArgs = array(
@@ -803,6 +839,46 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         if ($lifetime > self::MAX_LIFETIME) {
             Zend_Cache::throwException('Redis backend has a limit of 30 days (2592000 seconds) for the lifetime');
         }
+    }
+
+    /**
+     * Get the auto expiring lifetime.
+     *
+     * Mainly a workaround for the issues that arise due to the fact that
+     * Magento's Enterprise_PageCache module doesn't set any expiry.
+     *
+     * @param  int $specificLifetime
+     * @param  string $id
+     * @return int Cache life time
+     */
+    protected function _getAutoExpiringLifetime($lifetime, $id)
+    {
+        if ($lifetime || !$this->_autoExpireLifetime) {
+            // If it's already truthy, or there's no auto expire go with it.
+            return $lifetime;
+        }
+
+        $matches = $this->_matchesAutoExpiringPattern($id);
+        if (!$matches) {
+            // Only apply auto expire for keys that match the pattern
+            return $lifetime;
+        }
+
+        if ($this->_autoExpireLifetime > 0) {
+            // Return the auto expire lifetime if set
+            return $this->_autoExpireLifetime;
+        }
+
+        // Return whatever it was set to.
+        return $lifetime;
+    }
+
+    protected function _matchesAutoExpiringPattern($id)
+    {
+        $matches = array();
+        preg_match($this->_autoExpirePattern, $id, $matches);
+
+        return !empty($matches);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Works with any Zend Framework project including all versions of Magento!
  - Supports unix socket connection for even better performance on a single machine.
  - Supports configurable compression for memory savings. Can choose between gzip, lzf and snappy and can change configuration without flushing cache.
  - Uses transactions to prevent race conditions between saves, cleans or removes causing unexpected results.
+ - Supports a configurable "auto expiry lifetime" which, if set, will be used as the TTL when the key otherwise wouldn't expire. In combination with "auto expiry refresh on load" offers a more sane cache management strategy for Magento's `Enterprise_PageCache` module.
  - __Unit tested!__
 
 ## INSTALLATION (Magento)
@@ -66,6 +67,8 @@ Works with any Zend Framework project including all versions of Magento!
             <connect_retries>1</connect_retries>    <!-- Reduces errors due to random connection failures -->
             <lifetimelimit>57600</lifetimelimit>    <!-- 16 hours of lifetime for cache record -->
             <compress_data>0</compress_data>        <!-- DISABLE compression for EE FPC since it already uses compression -->
+            <auto_expire_lifetime></auto_expire_lifetime> <!-- Force an expiry (Enterprise_PageCache will not set one) -->
+            <auto_expire_refresh_on_load></auto_expire_refresh_on_load> <!-- Refresh keys when loaded (Keeps cache primed frequently requested resources) -->
           </backend_options>
         </full_page_cache>
 

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
     ],
     "require":{
         "magento-hackathon/magento-composer-installer":"*"
+    },
+    "autoload": {
+        "classmap": [
+            "Cm/Cache/Backend/Redis.php"
+        ]
     }
 }

--- a/tests/RedisBackendAutoExpiryTest.php
+++ b/tests/RedisBackendAutoExpiryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+==New BSD License==
+
+Copyright (c) 2012, Colin Mollenhour
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The name of Colin Mollenhour may not be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once 'RedisBackendTest.php';
+
+/**
+ * @copyright  Copyright (c) 2012 Colin Mollenhour (http://colin.mollenhour.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Zend_Cache_RedisAutoExpiryBackendTest extends Zend_Cache_RedisBackendTest {
+
+    protected $autoExpireLifetime = 3600;
+
+    protected $autoExpireRefreshOnLoad = 1;
+
+    public function testAutoExpiry()
+    {
+        $id = 'REQEST';
+        $data = 'foo';
+        $tags = array('tag1');
+        $this->_instance->save($data, $id, $tags, null);
+        $metadata = $this->_instance->getMetadatas($id);
+        $this->assertGreaterThan(1, $metadata['expire']);
+        sleep(1);
+        $this->_instance->load($id);
+        $nextMetadata = $this->_instance->getMetadatas($id);
+        $this->assertGreaterThan($metadata['expire'], $nextMetadata['expire']);
+    }
+}

--- a/tests/RedisBackendTest.php
+++ b/tests/RedisBackendTest.php
@@ -43,6 +43,10 @@ class Zend_Cache_RedisBackendTest extends Zend_Cache_CommonExtendedBackendTest {
 
     protected $forceStandalone = FALSE;
 
+    protected $autoExpireLifetime = 0;
+
+    protected $autoExpireRefreshOnLoad = 0;
+
     /** @var Cm_Cache_Backend_Redis */
     protected $_instance;
 
@@ -63,6 +67,8 @@ class Zend_Cache_RedisBackendTest extends Zend_Cache_CommonExtendedBackendTest {
             'compression_lib' => 'gzip',
             'use_lua' => TRUE,
             'lua_max_c_stack' => self::LUA_MAX_C_STACK,
+            'auto_expire_lifetime' => $this->autoExpireLifetime,
+            'auto_expire_refresh_on_load' => $this->autoExpireRefreshOnLoad,
         ));
         $this->_instance->clean(Zend_Cache::CLEANING_MODE_ALL);
         $this->_instance->___scriptFlush();


### PR DESCRIPTION
This merges master into the sentinels-and-slaves and then patches Cm_Cache_Backend_Redis to implement callback based policy for what slave to be picked. This 'slave-select' option needs to be documented, and possibly cleaned up.

I'm open to suggestions for a better interface and feedback. I currently use this functionality to prefer the (any) local slave over picking a random slave https://github.com/Xon/XenForo-RedisCache/blob/master/upload/library/Zend/Cache/Backend/Redis.php#L18-L61

This process is horrible since there doesn't appear to be a standard way to get all local IPs that php can see. as such, I haven't included it in this pull request.