### PR TITLE
Add support for using ElastiCache Cluster replica nodes for reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,40 @@ Example configuration:
           </backend_options>
         </cache>
 
+## ElastiCache
+
+The following example configuration lets you use ElastiCache Redis (cluster mode disabled) where the writes are sent to the Primary node and reads are sent to the replicas. This lets you distribute the read traffic between the different nodes.  
+
+The instructions to find the primary and read replica endpoints are [here](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Endpoints.html#Endpoints.Find.Redis).
+
+        <!-- This is a child node of config/global/cache -->
+        <backend_options>
+          <server>primary-endpoint.0001.euw1.cache.amazonaws.com</server>
+          <port>6379</port>
+          <database>0</database>        <!-- Make sure database is 0 -->
+          .
+          . <!-- Other settings -->
+          .
+          <cluster>
+            <master>
+              <node-001>
+                <server>primary-endpoint.0001.euw1.cache.amazonaws.com</server>
+                <port>6379</port>
+              </node-001>
+            </master>
+            <slave>
+              <node-001>
+                <server>replica-endpoint-1.jwbaun.0001.euw1.cache.amazonaws.com</server>
+                <port>6379</port>
+              </node-001>
+              <node-002>
+                <server>replica-endpoint-2.jwbaun.0001.euw1.cache.amazonaws.com</server>
+                <port>6379</port>
+              </node-002>
+            </slave>
+          </cluster>
+        </backend_options>
+
 ## RELATED / TUNING
 
  - The recommended "maxmemory-policy" is "volatile-lru". All tag metadata is non-volatile so it is


### PR DESCRIPTION
Hi,

We were hitting the bandwidth for the ElastiCache so I implemented a small extension that takes the Primary and replica endpoints and starts sending reads to replica nodes and writes to primary nodes.

We thought it might be useful to someone else so just sharing, it has been working pretty great.

Edit: Just want to reference the orignial source for doing this: https://magento.stackexchange.com/a/122571