### PR TITLE
Added 'retry_reads_on_master' option for when read slaves are used

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -112,6 +112,13 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
     protected $_luaMaxCStack = 5000;
 
     /**
+     * If 'retry_reads_on_master' is truthy then reads will be retried against master when slave returns "(nil)" value
+     *
+     * @var boolean
+     */
+    protected $_retryReadsOnMaster = false;
+
+    /**
      * @var stdClass
      */
     protected $_clientOptions;
@@ -339,6 +346,10 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
             $this->_luaMaxCStack = (int) $options['lua_max_c_stack'];
         }
 
+        if (isset($options['retry_reads_on_master'])) {
+            $this->_retryReadsOnMaster = (bool) $options['retry_reads_on_master'];
+        }
+
         if (isset($options['auto_expire_lifetime'])) {
             $this->_autoExpireLifetime = (int) $options['auto_expire_lifetime'];
         }
@@ -441,6 +452,11 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
     {
         if ($this->_slave) {
             $data = $this->_slave->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
+
+            // Prevent compounded effect of cache flood on asynchronously replicating master/slave setup
+            if ($this->_retryReadsOnMaster && $data === false) {
+                $data = $this->_redis->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
+            }
         } else {
             $data = $this->_redis->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
         }


### PR DESCRIPTION
I recently supported the infrastructure launch on a Magento 2 site which sees high enough traffic levels to require the use of a read slave for the object cache. Without the slave, cache reads will saturate the 1Gbps interface between the web servers and the master Redis instance.

During pre-launch load testing, everything worked great and we reached proper traffic levels by simply adding a read slave to each of the web servers and configuring the `load_from_slave` option on the cache backend. This eliminated the network interface as a bottleneck as well as lowered overall application response times by around 50-60 ms on average (because there is practically no latency to redis on cache hits now). But this was without a long-list of heavy hitting integrations that result in _lots_ of cache purging activity for short periods of time (integrations which are out of our control).

Once live we kept experiencing instances of application responses spiking. They were seemingly very random and didn't always correlate to said integrations, but did seem to be either timing wise around these integrations slamming the API and/or admins editing products in the backend.

When a cache flush occurs, there is always a cache flood, especially when under high traffic. The net effect of this is compounded when read slaves are used. Under the circumstances we experienced the performance degradation severe enough to grind things to a halt a couple times during a flash sale and the impact to the redis replication was a toppling effect resulting in floods of `LOADING Redis is loading the dataset in memory` errors as they continued trying to perform full re-synchronizations due to the cache floods filling replication buffers of over 4 GB in size.

The solution to this problem was to add support for the `retry_reads_on_master` setting to make configurable the retry of reads on master when the read comes back from the slave as empty. _This has been in production for 5 days now_ and the error _has not reoccurred_.

The below is a screenshot of what happens to the object cache during these steady and repeated cache floods. The giant spike in the purple graph is not an increase in data, but a replication buffer filling up to over 4 GB of writes (from the cache floods)

![magento overview created via terraform datadog 2018-09-21 08-49-52](https://user-images.githubusercontent.com/658281/45885292-aa43d780-bd7b-11e8-83cc-1c7c5e66f5ad.png)

The solution of simply retrying empty read responses on master has the effect of bringing the impact of a cache flood back to where it was when only a master redis instance was used, allows us to put the replication buffer back down to 768 mb (it could probably go even lower without issue, but we're stable now, so I'm not changing it).

These are the settings we used on the replicating redis instances:

```
repl-diskless-sync yes
repl-backlog-size 256mb
client-output-buffer-limit slave 768mb 768mb 0
```

Cache backend configuration in the `env.php` file now looks like this:

```
  'cache' => 
  array (
    'frontend' => 
    array (
      'default' => 
      array (
        'backend' => 'Cm_Cache_Backend_Redis',
        'backend_options' => 
        array (
          'server' => '940365-masterdb',
          'port' => '6379',
          'load_from_slave' => 'tcp://127.0.0.1:6379',
          'retry_reads_on_master' => '1',
        ),
      ),
    ),
  ),
```

Let me know if there are questions. I'd love to see this merged in so it can trickle it's way down into the core and allow us to eventually remove our package override in the composer.json for this site. :)