### PR TITLE
Casting to INT on line 516 fixes Redis Expire Warning Redis::expire()…

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -513,7 +513,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         else
             $tags = array_flip(array_flip($tags));
 
-        $lifetime = $this->_getAutoExpiringLifetime($this->getLifetime($specificLifetime), $id);
+        $lifetime = (int)$this->_getAutoExpiringLifetime($this->getLifetime($specificLifetime), $id);
 
         if ($this->_useLua) {
             $sArgs = array(


### PR DESCRIPTION
… expects parameter 2 to be integer, string given



Warning: Redis::expire() expects parameter 2 to be integer, string given  in app/code/local/Credis/Client.php on line 1141

#0 [internal function]: mageCoreErrorHandler(2, 'Redis::expire()...', '/var/www/html/s...', 1141, Array)
#1 app/code/local/Credis/Client.php(1141): Redis->expire('zc:k:64d_7C0BC4...', 'null')
#2 app/code/community/Cm/Cache/Backend/Redis.php(597): Credis_Client->__call('expire', Array)
#3 lib/Zend/Cache/Core.php(390): Cm_Cache_Backend_Redis->save('', '64d_7C0BC419974...', Array, 'null')
#4 lib/Varien/Cache/Core.php(145): Zend_Cache_Core->save('', '64d_7C0BC419974...', Array, 'null', 8)