### PR TITLE
[FIX] Make redis cache backend work like builtin cache

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -623,7 +623,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         }
 
         // Set expiration if specified
-        if ($lifetime !== false) {
+        if ($lifetime !== false && !is_null($lifetime)) {
           $this->_redis->expire(self::PREFIX_KEY.$id, min($lifetime, self::MAX_LIFETIME));
         }
 

--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -616,14 +616,14 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
           self::FIELD_DATA => $this->_encodeData($data, $this->_compressData),
           self::FIELD_TAGS => $this->_encodeData(implode(',',$tags), $this->_compressTags),
           self::FIELD_MTIME => time(),
-          self::FIELD_INF => $lifetime ? 0 : 1,
+          self::FIELD_INF => is_null($lifetime) ? 1 : 0,
         ));
         if( ! $result) {
             throw new CredisException("Could not set cache key $id");
         }
 
         // Set expiration if specified
-        if ($lifetime) {
+        if ($lifetime !== false) {
           $this->_redis->expire(self::PREFIX_KEY.$id, min($lifetime, self::MAX_LIFETIME));
         }
 


### PR DESCRIPTION
Setting lifetime to 0 evaluates to falsey, causing the infinite time
flag to be set to true. It also causes the expire to not be set.
According to docblock infinity should only be set iff lifetime is null.
This makes that work as expected and like magento cache works by
default.