### PR TITLE
Avoid expiration life time when $specificLifetime has not passed in f…

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -543,7 +543,8 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         else
             $tags = array_flip(array_flip($tags));
 
-        $lifetime = (int)$this->_getAutoExpiringLifetime($this->getLifetime($specificLifetime), $id);
+        $lifetime = $this->_getAutoExpiringLifetime($this->getLifetime($specificLifetime), $id);
+        $lifetime = $lifetime === null ? $lifetime : (int) $lifetime;
 
         if ($this->_useLua) {
             $sArgs = array(


### PR DESCRIPTION
Avoid expiration life time when $specificLifetime has not passed in function, the casting "(int)" to "null" value is equals a "0":

Summary:

        //If the function returns a null, the casting transform null to 0!
        $lifetime = (int)$this->_getAutoExpiringLifetime($this->getLifetime($specificLifetime), $id);

        //If $lifetime is 0 enter and expire the key...
        if ($lifetime !== false && !is_null($lifetime)) {
          $this->_redis->expire(self::PREFIX_KEY.$id, min($lifetime, self::MAX_LIFETIME));
        }
