### PR TITLE
Updated to Support Sentinel Auth

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -174,10 +174,9 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
                     if ($sentinelClientOptions->readTimeout) {
                         $sentinelClient->setReadTimeout($sentinelClientOptions->readTimeout);
                     }
-                    // Sentinel currently doesn't support AUTH
-                    //if ($password) {
-                    //    $sentinelClient->auth($password) or Zend_Cache::throwException('Unable to authenticate with the redis sentinel.');
-                    //}
+                    if ($sentinelClientOptions->password) {
+                        $sentinelClient->auth($sentinelClientOptions->password) or Zend_Cache::throwException('Unable to authenticate with the redis sentinel.');
+                    }
                     $sentinel = new Credis_Sentinel($sentinelClient);
                     $sentinel
                         ->setClientTimeout($this->_clientOptions->timeout)


### PR DESCRIPTION
Added Configuration with Sentinel AUTH Support.

Currently using Kubernetes setup using helm chart helm/stable/redis.
Default setup of Sentinel enforces AUTH, and commenting this solves connection issues.
