### PR TITLE
Fix PHP 8.1 Warning: Trying to access array offset on value of type bool

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -702,7 +702,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
 
         $result = $this->_redis->exec();
 
-        return (bool) $result[0];
+        return isset($result[0]) ? (bool)$result[0] : false;
     }
 
     /**


### PR DESCRIPTION
In PHP 8.1 **Notice: Undefined offset: 0** changed to **Warning: Undefined array key 0**, so I changed it to avoid this error not depending on any PHP version  