### PR TITLE
Handle LOADING state as if key was not found.

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -499,9 +499,10 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
             try {
                 $data = $this->_redis->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
             } catch (CredisException $e) {
-                // Respond as if key not found when dataset is loading
+                // Retry once after 1 second when dataset is loading
                 if ($e->getMessage() === 'LOADING Redis is loading the dataset in memory') {
-                    $data = FALSE;
+                    sleep(1);
+                    $data = $this->_redis->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
                 } else {
                     throw $e;
                 }


### PR DESCRIPTION
This PR attempts to address the "LOADING Redis is loading the dataset in memory" error first reported in https://github.com/colinmollenhour/Cm_Cache_Backend_Redis/pull/134 - that PR seems to not work fully as intended as an exception is thrown instead of `false` returned when this error occurs - perhaps this was changed long ago in an older version of Redis.

Also, when master incurs a `LOADING` error (e.g. as could happen briefly in case there was a failover mid-request) it will wait one time for one second and make a second attempt to hopefully reduce the impact of the `LOADING` error while not putting the server in jeopardy for a longer wait time.