### PR TITLE
Load from master

### DIFF
--- a/Cm/Cache/Backend/Redis.php
+++ b/Cm/Cache/Backend/Redis.php
@@ -392,6 +392,8 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
         if (isset($options['auto_expire_refresh_on_load'])) {
             $this->_autoExpireRefreshOnLoad = (bool) $options['auto_expire_refresh_on_load'];
         }
+
+        $this->_directives['load_from_master'] = false;
     }
 
     /**
@@ -481,7 +483,7 @@ class Cm_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_Ba
      */
     public function load($id, $doNotTestCacheValidity = false)
     {
-        if ($this->_slave) {
+        if ($this->_slave && empty($this->_directives['load_from_master'])) {
             try {
                 $data = $this->_slave->hGet(self::PREFIX_KEY.$id, self::FIELD_DATA);
 

--- a/README.md
+++ b/README.md
@@ -4,24 +4,22 @@ Works with any Zend Framework project including all versions of Magento!
 
 # FEATURES
 
- - Uses the [phpredis PECL extension](https://github.com/nicolasff/phpredis) for best performance (requires **master** branch or tagged version newer than Aug 19 2011).
+ - Can take advantage of the [phpredis PECL extension](https://github.com/phpredis/phpredis) for best performance if it is installed.
  - Falls back to standalone PHP if phpredis isn't available using the [Credis](https://github.com/colinmollenhour/credis) library.
  - Tagging is fully supported, implemented using the Redis "set" and "hash" data types for efficient tag management.
  - Key expiration is handled automatically by Redis.
  - Supports unix socket connection for even better performance on a single machine.
- - Supports configurable compression for memory savings. Can choose between gzip, lzf and snappy and can change configuration without flushing cache.
+ - Supports configurable compression for memory savings. Can choose between gzip, lzf, l4z, snappy and zstd and can change configuration without flushing cache.
  - Uses transactions to prevent race conditions between saves, cleans or removes causing unexpected results.
  - Supports a configurable "auto expiry lifetime" which, if set, will be used as the TTL when the key otherwise wouldn't expire. In combination with "auto expiry refresh on load" offers a more sane cache management strategy for Magento's `Enterprise_PageCache` module.
+ - Supports reading from slaves, can be overridden at run time by setting the 'load_from_master' directive.
+ - Can read connection info from Redis Sentinel for automatic failovers.
  - __Unit tested!__
 
 # REQUIREMENTS
 
-As this backend uses [Credis](https://github.com/colinmollenhour/credis) there are no additional requirements, but for improved performance you can install [phpredis](https://github.com/nicolasff/phpredis) which is a compiled extension.
-
-   * For 2.4 support you must use the "master" branch or a tagged version newer than Aug 19, 2011.
-   * phpredis is optional, but it is much faster than standalone mode
-   * phpredis does not support setting read timeouts at the moment (see pull request #260). If you receive read errors (“read error on connection”), this
-     might be the reason.
+This backend uses the [Credis](https://github.com/colinmollenhour/credis) library.
+Optionally, but for improved performance, you can install [phpredis](https://github.com/phpredis/phpredis) which is a compiled extension and available via pecl and many official packages.
 
 # INSTALLATION
 

--- a/tests/CommonBackendTest.php
+++ b/tests/CommonBackendTest.php
@@ -80,6 +80,13 @@ abstract class CommonBackendTest extends TestCase
         $this->assertTrue($res);
     }
 
+    public function testSaveWithEmptyString(): void
+    {
+        $this->_instance->setDirectives(array('lifetime' => 3600));
+        $this->assertTrue($this->_instance->save('', 'empty'));
+        $this->assertEquals('', $this->_instance->load('empty'));
+    }
+
     public function testRemoveCorrectCall(): void
     {
         $this->assertTrue($this->_instance->remove('bar'));

--- a/tests/RedisBackendTest.php
+++ b/tests/RedisBackendTest.php
@@ -213,4 +213,10 @@ class RedisBackendTest extends CommonExtendedBackendTest
         $this->_instance->clean(Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG, ['x']);
         $this->assertEquals(['clean'], $this->_instance->___checkScriptsExist());
     }
+
+    public function testLoadFromMaster(): void
+    {
+        $this->_instance->setDirectives(['load_from_master' => true]);
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
Add 'load_from_master' directive for overriding read from slaves on the fly in case one needs to ensure that replication lag cannot introduce race conditions.